### PR TITLE
Fix client crashing if loaded files don't exist anymore

### DIFF
--- a/CSharpMinifier.GUI/frmMain.cs
+++ b/CSharpMinifier.GUI/frmMain.cs
@@ -33,13 +33,13 @@ namespace CSharpMinifier.GUI
 			foreach (var fileName in fileNames)
 			{
 				var lbItem = new ListBoxItem(fileName, Path.GetFileName(fileName));
-                try
-                {
-                    Sources[lbItem.Key] = File.ReadAllText(lbItem.Key);
-                    lbInputFiles.Items.Add(lbItem);
-                }
-                catch(Exception e)
-                { }
+				try
+				{
+					Sources[lbItem.Key] = File.ReadAllText(lbItem.Key);
+					lbInputFiles.Items.Add(lbItem);
+				}
+				catch(Exception e)
+				{ }
                 
 			}
 		}

--- a/CSharpMinifier.GUI/frmMain.cs
+++ b/CSharpMinifier.GUI/frmMain.cs
@@ -33,8 +33,14 @@ namespace CSharpMinifier.GUI
 			foreach (var fileName in fileNames)
 			{
 				var lbItem = new ListBoxItem(fileName, Path.GetFileName(fileName));
-				Sources[lbItem.Key] = File.ReadAllText(lbItem.Key);
-				lbInputFiles.Items.Add(lbItem);
+                try
+                {
+                    Sources[lbItem.Key] = File.ReadAllText(lbItem.Key);
+                    lbInputFiles.Items.Add(lbItem);
+                }
+                catch(Exception e)
+                { }
+                
 			}
 		}
 


### PR DESCRIPTION
This commit wraps the loading of recently opened files into a try-catch statement to prevent crashes on launch.